### PR TITLE
Issues #6 and #9 solved

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -95,6 +95,8 @@ async function makeWordsClickable() {
             clearFocus();
             word.toggleClass("focus");
             updateCard(word);
+            card.classList.remove("closed");
+            cardContent.classList.remove("invisible");
         })
     });
 }
@@ -154,6 +156,7 @@ const card_close = card.querySelector(".close")
 
 const cardTitle = card.querySelector(".title");
 const cardInfo = card.querySelector(".grammar ul");
+const cardContent = card.querySelector("#lookup_card_content")
 
 async function updateCard(word) { // word is an element
     cardTitle.innerHTML = word.html();
@@ -229,7 +232,6 @@ card_close.addEventListener("click", () => closeCard())
 
 function hideCard() {
     card.classList.toggle("closed");
-    cardContent = card.querySelector("#lookup_card_content");
     cardContent.classList.toggle("invisible");
 }
 

--- a/style.css
+++ b/style.css
@@ -104,7 +104,7 @@ button {
 }
 
 /*** Dynamic classes ***/
-.w, .cardbutton {
+.w, .close, .hide {
   cursor: pointer;
 }
 .w:hover {
@@ -160,7 +160,7 @@ span.verse_ref {
   font-size: xx-large;
   text-align: center;
 }
-.cardbutton:hover {
+.close:hover, .hide:hover {
   background: #bbb;
 }
 .animate {


### PR DESCRIPTION
Closes #6 by removing `closed` and `invisible` classes from respective elements when clicking a word. (This therefore works both for new words and for the same word being clicked again. This is desirable since a user may click a word again as an alternative to unhiding the card.)

Closes #9 solved by removing the `.cardbutton` class which is obsolete and replacing with `.hide` and `.close`. This may cause problems ahead if I these classes are used for non-card elements.